### PR TITLE
feat(diff): Tokyo Night theme for hunk and delta

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -10,6 +10,15 @@
 
 [core]
 	ignorecase = false
+	pager = delta
+
+[interactive]
+	diffFilter = delta --color-only
+
+[delta]
+	navigate = true
+	line-numbers = true
+	side-by-side = true
 
 [filter "lfs"]
 	process = git-lfs filter-process
@@ -53,3 +62,6 @@
 	provider = generic
 [ghq]
 	root = ~/ghq
+
+[include]
+	path = ~/.config/git/tokyonight_night.gitconfig

--- a/.config/git/tokyonight_night.gitconfig
+++ b/.config/git/tokyonight_night.gitconfig
@@ -1,0 +1,12 @@
+[delta]
+  minus-style                   = syntax "#4a272f"
+  minus-non-emph-style          = syntax "#4a272f"
+  minus-emph-style              = syntax "#713137"
+  minus-empty-line-marker-style = syntax "#4a272f"
+  line-numbers-minus-style      = "#914c54"
+  plus-style                    = syntax "#243e4a"
+  plus-non-emph-style           = syntax "#243e4a"
+  plus-emph-style               = syntax "#2c5a66"
+  plus-empty-line-marker-style  = syntax "#243e4a"
+  line-numbers-plus-style       = "#449dab"
+  line-numbers-zero-style       = "#3b4261"

--- a/.config/hunk/config.toml
+++ b/.config/hunk/config.toml
@@ -1,2 +1,71 @@
-theme = "graphite"
+theme = "custom"
 mode = "auto"
+
+# Tokyo Night (night variant)
+# Diff 配色は tokyonight 公式 delta テーマ (folke/tokyonight.nvim extras/delta/tokyonight_night.gitconfig) を採用
+# Diff 周辺以外 (panel/text/border 等) は ssaunderss/zed-tokyo-night theme JSON の値
+[custom_theme]
+base = "catppuccin-mocha"
+label = "Tokyo Night"
+
+# Surfaces (Zed theme JSON 直)
+background = "#1a1b26"
+panel = "#16161e"
+panelAlt = "#1a1b26"
+border = "#101014"
+accent = "#7dcfff"
+accentMuted = "#202330"
+text = "#a9b1d6"
+muted = "#787c99"
+
+# Diff bg: delta plus-style / minus-style
+addedBg = "#243e4a"
+removedBg = "#4a272f"
+movedAddedBg = "#243e4a"
+movedRemovedBg = "#4a272f"
+contextBg = "#1a1b26"
+
+# Word emph: delta plus-emph-style / minus-emph-style
+addedContentBg = "#2c5a66"
+removedContentBg = "#713137"
+contextContentBg = "#1a1b26"
+
+# Sign bar / +/- 記号: delta line-numbers-{plus,minus}-style
+addedSignColor = "#449dab"
+removedSignColor = "#914c54"
+
+lineNumberBg = "#1a1b26"
+# delta line-numbers-zero-style
+lineNumberFg = "#3b4261"
+selectedHunk = "#1e202e"
+
+# Badge は sign 色と整合 (delta 系)
+badgeAdded = "#449dab"
+badgeRemoved = "#914c54"
+badgeNeutral = "#787c99"
+
+# File status (Zed version_control.* と一致)
+fileNew = "#9ece6a"
+fileDeleted = "#f7768e"
+fileRenamed = "#7dcfff"
+fileModified = "#e0af68"
+fileUntracked = "#9ece6a"
+
+# Note 系は Zed 相当無し、tokyonight 直の値を維持
+noteBorder = "#7aa2f7"
+noteBackground = "#16161e"
+noteTitleBackground = "#1f2335"
+noteTitleText = "#a9b1d6"
+
+# Syntax は Zed 相当キーが別カテゴリのため tokyonight nvim 直の値を維持
+# (Zed の syntax.{string,keyword,...} と概ね一致するが厳密値は別 task)
+[custom_theme.syntax]
+default = "#a9b1d6"
+keyword = "#bb9af7"
+string = "#9ece6a"
+comment = "#565f89"
+number = "#ff9e64"
+function = "#7aa2f7"
+property = "#73daca"
+type = "#2ac3de"
+punctuation = "#a9b1d6"


### PR DESCRIPTION
## Summary
- `hunk` (TUI diff viewer) に Tokyo Night night カスタムテーマを追加
- `delta` を git の pager として有効化、tokyonight 公式 delta gitconfig を vendoring
- diff bg / word emph の色は両者で同一 hex (`#243e4a` / `#4a272f` / `#2c5a66` / `#713137`) ― tokyonight 公式 delta パレット由来

## 変更ファイル
- `.config/hunk/config.toml` — `[custom_theme]` セクションで delta 値を 1:1 マッピング、palette/text 等は ssaunderss/zed-tokyo-night theme JSON 由来
- `.config/git/config` — `core.pager = delta`、`interactive.diffFilter`、`delta.{navigate,line-numbers,side-by-side}`、tokyonight gitconfig の include
- `.config/git/tokyonight_night.gitconfig` — folke/tokyonight.nvim の extras から vendor

## Test plan
- [ ] `hunk diff` で working tree の差分が tokyonight 配色で表示される
- [ ] `git diff` が delta + tokyonight 配色で side-by-side 表示される
- [ ] `git diff --staged` も同様
- [ ] hunk と delta で diff 行 bg / word emph の hex が一致していることを目視確認