### PR TITLE
fix(linux): apt に無い ghq を release binary 導入に切り替える

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ ghq get https://github.com/yasainet/dotfiles
 cd ~/ghq/github.com/yasainet/dotfiles
 ./install.sh
 
-exex zsh
+exec zsh
 ```
 
 ### Linux (Ubuntu)

--- a/README.md
+++ b/README.md
@@ -16,12 +16,11 @@ brew install ghq
 ghq get https://github.com/yasainet/dotfiles
 cd ~/ghq/github.com/yasainet/dotfiles
 ./install.sh
+
+exex zsh
 ```
 
 ### Linux (Ubuntu)
-
-`ghq` は apt に無いため、`install.sh` が release binary を `~/.local/bin` に入れる。
-初回だけ `git clone` で ghq のディレクトリ構成に合わせて配置する。
 
 ```sh
 sudo apt update && sudo apt install -y git
@@ -29,9 +28,9 @@ sudo apt update && sudo apt install -y git
 git clone https://github.com/yasainet/dotfiles ~/ghq/github.com/yasainet/dotfiles
 cd ~/ghq/github.com/yasainet/dotfiles
 ./install.sh
-```
 
-`install.sh` は `chsh` で zsh を default shell にする。反映には再ログインが必要。
+exec zsh
+```
 
 ### Rename machine (macOS)
 
@@ -51,9 +50,9 @@ scutil --get ComputerName
 ### Sync ghq project .env files across machines
 
 ```sh
-# Old machine: back up
+# Back up
 ./scripts/sync-envs.sh backup
 
-# New machine: `ghq get` the projects first, then restore
+# Restore
 ./scripts/sync-envs.sh restore
 ```

--- a/README.md
+++ b/README.md
@@ -20,13 +20,18 @@ cd ~/ghq/github.com/yasainet/dotfiles
 
 ### Linux (Ubuntu)
 
-```sh
-sudo apt update && sudo apt install -y git ghq
+`ghq` は apt に無いため、`install.sh` が release binary を `~/.local/bin` に入れる。
+初回だけ `git clone` で ghq のディレクトリ構成に合わせて配置する。
 
-ghq get https://github.com/yasainet/dotfiles
+```sh
+sudo apt update && sudo apt install -y git
+
+git clone https://github.com/yasainet/dotfiles ~/ghq/github.com/yasainet/dotfiles
 cd ~/ghq/github.com/yasainet/dotfiles
 ./install.sh
 ```
+
+`install.sh` は `chsh` で zsh を default shell にする。反映には再ログインが必要。
 
 ### Rename machine (macOS)
 
@@ -45,9 +50,6 @@ scutil --get ComputerName
 
 ### Sync ghq project .env files across machines
 
-`.env*` files under `~/ghq/**` are not tracked by git.
-The helper script mirrors them through iCloud Drive.
-
 ```sh
 # Old machine: back up
 ./scripts/sync-envs.sh backup
@@ -55,5 +57,3 @@ The helper script mirrors them through iCloud Drive.
 # New machine: `ghq get` the projects first, then restore
 ./scripts/sync-envs.sh restore
 ```
-
-Destination: `~/Library/Mobile Documents/com~apple~CloudDocs/Documents/.envs/`

--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -13,8 +13,8 @@ install_cli_tools() {
   sudo apt install -y locales
   sudo locale-gen en_US.UTF-8
 
-  sudo apt install -y curl wget zsh software-properties-common
-  sudo apt install -y bat btop fd-find fzf ghq ripgrep tree jq
+  sudo apt install -y curl wget unzip zsh software-properties-common
+  sudo apt install -y bat btop fd-find fzf ripgrep tree jq
   sudo apt install -y zsh-autosuggestions zsh-syntax-highlighting
 
   # Neovim
@@ -26,6 +26,43 @@ install_cli_tools() {
   fi
   sudo apt install -y ffmpeg
   sudo apt install -y xclip
+}
+
+# ====================
+# ghq (no apt package on Ubuntu)
+# ====================
+GHQ_VERSION="v1.10.1"
+
+install_ghq() {
+  if command -v ghq &> /dev/null; then
+    echo "ghq already installed"
+    return
+  fi
+
+  local arch
+  case "$(uname -m)" in
+    x86_64)  arch="amd64" ;;
+    aarch64) arch="arm64" ;;
+    *)
+      echo "  [skip] ghq (unsupported arch: $(uname -m))"
+      return
+      ;;
+  esac
+
+  echo "Installing ghq $GHQ_VERSION..."
+
+  local name="ghq_linux_${arch}"
+  local tmp
+  tmp="$(mktemp -d)"
+  curl -fsSL -o "$tmp/ghq.zip" \
+    "https://github.com/x-motemen/ghq/releases/download/${GHQ_VERSION}/${name}.zip"
+  unzip -q "$tmp/ghq.zip" -d "$tmp"
+
+  mkdir -p "$HOME/.local/bin"
+  install -m 755 "$tmp/$name/ghq" "$HOME/.local/bin/ghq"
+  rm -rf "$tmp"
+
+  echo "  [done] ghq -> $HOME/.local/bin/ghq"
 }
 
 # ====================
@@ -69,6 +106,7 @@ install_zsh_plugins() {
 # ====================
 install_packages() {
   install_cli_tools
+  install_ghq
   set_default_shell
   install_zsh_plugins
 }


### PR DESCRIPTION
## 問題

Ubuntu 24.04 の apt に `ghq` パッケージが存在せず、`install_cli_tools` の

```sh
sudo apt install -y bat btop fd-find fzf ghq ripgrep tree jq
```

が `E: Unable to locate package ghq` で失敗する。apt は 1 つでも解決できない
パッケージがあると行ごと中断するため、`set -e` で `install.sh` 全体が停止していた。
実機 (queen / Ubuntu 24.04.4 LTS) で再現を確認。

## 変更

- `scripts/linux.sh`
  - apt のリストから `ghq` を削除し、展開用に `unzip` を追加
  - `install_ghq()` を追加 — GitHub release の zip を `~/.local/bin/ghq` に展開する
    - version は `GHQ_VERSION` で pin (v1.10.1)
    - `command -v ghq` で早期 return し冪等
    - `uname -m` で amd64 / arm64 を判定、それ以外は skip
  - `install_packages()` に `install_ghq` を追加
- `README.md`
  - Linux 手順を `ghq get` から `git clone` に変更 (ghq 自体を install.sh が入れるため)
  - 各手順に `exec zsh` を追記

## 検証

- `bash -n scripts/linux.sh install.sh` — 構文 OK
- sandbox HOME + `uname -m` stub で `install_ghq` を実行
  → `ELF 64-bit LSB executable, x86-64` が mode 755 で配置され、2 回目は skip
- queen 上で `apt-get install -s` — 新しいパッケージリストが全て解決

🤖 Generated with [Claude Code](https://claude.com/claude-code)